### PR TITLE
node 8 buffers are now zero initialized …

### DIFF
--- a/readlines.js
+++ b/readlines.js
@@ -85,6 +85,10 @@ LineByLine.prototype._extractLines = function(buffer) {
 };
 
 LineByLine.prototype._readChunk = function(lineLeftovers) {
+    if (this.eofReached === true) {
+      return 0;
+    }
+
     var bufferData = new Buffer(this.options.readChunk);
 
     var totalBytesRead = 0;


### PR DESCRIPTION
…so the _readChunk method would never exit if a line didn't end with a newline.

In node < 8, new buffers were not initialized so the _readChunk look would eventually allocate a buffer with a newline character in the random data.  But the readSync calls would all have returned 0 bytes read so the _readChunk would return 0.

Starting with node 8, new Buffers are zero initialized so the loop (buffer allocate>readSync>Check for newline) would never exit.  If eofReached is set to true, this avoids all this and returns immediately.