### PR TITLE
Allow using 0 as file descriptor

### DIFF
--- a/readlines.js
+++ b/readlines.js
@@ -116,7 +116,7 @@ class LineByLine {
     }
 
     next() {
-        if (!this.fd) return false;
+        if (this.fd == null) return false;
 
         let line = false;
 


### PR DESCRIPTION
The standard unix file descriptor for stdin is 0 (also available as process.stdin.fd), but this is not possible to use since 0 is a falsy value. This commit fixes this.