### PR TITLE
feat: add support for STDIN

### DIFF
--- a/readlines.js
+++ b/readlines.js
@@ -89,7 +89,7 @@ class LineByLine {
         do {
             const readBuffer = new Buffer(this.options.readChunk);
 
-            bytesRead = fs.readSync(this.fd, readBuffer, 0, this.options.readChunk, this.fdPosition);
+            bytesRead = fs.readSync(this.fd, readBuffer, 0, this.options.readChunk, this.fd === process.stdin.fd ? undefined : this.fdPosition);
             totalBytesRead = totalBytesRead + bytesRead;
 
             this.fdPosition = this.fdPosition + bytesRead;
@@ -116,7 +116,7 @@ class LineByLine {
     }
 
     next() {
-        if (!this.fd) return false;
+        if (typeof this.fd !== 'number' && !this.fd) return false;
 
         let line = false;
 


### PR DESCRIPTION
Add support for STDIN by receiving file descriptor 0 as a valid argument and ignoring the position when reading from it as STDIN cannot be seeked (Perhaps we should prevent reset of this file but for now it works for my use case)

Fixes #37 