### PR TITLE
Bug: reading two lines as one

### DIFF
--- a/readlines.js
+++ b/readlines.js
@@ -98,6 +98,8 @@ class LineByLine {
         // Add any remaining content (incomplete line without newline)
         if (lineStart < buffer.length) {
             lines.push(buffer.slice(lineStart));
+        } else if (lineStart === buffer.length) {
+            lines.push(Buffer.alloc(0));
         }
 
         return lines;

--- a/readlines.js
+++ b/readlines.js
@@ -42,6 +42,7 @@ class LineByLine {
         this.linesCache = [];
         this.fdPosition = 0;
         this.lastChunkEndedWithCR = false;
+        this.lineIsComplete = false;
     }
 
     close() {
@@ -61,6 +62,7 @@ class LineByLine {
             lineStart = 1;
         }
         this.lastChunkEndedWithCR = false;
+        this.lineIsComplete = false;
 
         for (let i = lineStart; i < buffer.length; i++) {
             const byte = buffer[i];
@@ -99,7 +101,7 @@ class LineByLine {
         if (lineStart < buffer.length) {
             lines.push(buffer.slice(lineStart));
         } else if (lineStart === buffer.length) {
-            lines.push(Buffer.alloc(0));
+            this.lineIsComplete = true;
         }
 
         return lines;
@@ -166,7 +168,7 @@ class LineByLine {
 
             // Check if this might be an incomplete line (no newline found yet)
             // This happens when we read a chunk that doesn't contain a newline
-            if (!this.eofReached && this.linesCache.length === 0) {
+            if (!this.eofReached && !this.lineIsComplete && this.linesCache.length === 0) {
                 bytesRead = this._readChunk(line);
 
                 if (bytesRead && this.linesCache.length) {

--- a/test/fixtures/chunkSize32equalEOL.csv
+++ b/test/fixtures/chunkSize32equalEOL.csv
@@ -1,0 +1,2 @@
+1,user1,#FFFFFF,"message1 mess"
+1,user2,#FFFFFF,"message2"

--- a/test/readlines.test.js
+++ b/test/readlines.test.js
@@ -155,6 +155,14 @@ test('should correctly processes NULL character in lines', () => {
     assert.strictEqual(liner.fd, null, 'fd is null');
 });
 
+test('should read 2 lines', () => {
+    const liner = new lineByLine(path.resolve(__dirname, 'fixtures/chunkSize32equalEOL.csv'), { readChunk: 32 });
+
+    assert.strictEqual(liner.next().toString(), '1,user1,#FFFFFF,"message1 mess"', 'line 0: 1,user1,#FFFFFF,"message1 mess"');
+    assert.strictEqual(liner.next().toString(), '1,user2,#FFFFFF,"message2"', 'line 1: 1,user2,#FFFFFF,"message2"');
+    assert.strictEqual(liner.fd, null, 'fd is null');
+});
+
 // ============================================
 // LINE ENDING TESTS (LF, CRLF, CR)
 // ============================================


### PR DESCRIPTION
If the chunk size matches the end of the line, then the two lines are read as one.

Added test and my fix